### PR TITLE
STEP8: Add style for smaller screen sizes

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -10,6 +10,7 @@ body {
   font-family: 'Open Sans', sans-serif;
   font-weight: 300;
   line-height: 1.6;
+  overflow: hidden;
 }
 ol, ul {
   list-style-type: none;

--- a/css/layout.css
+++ b/css/layout.css
@@ -66,12 +66,10 @@
   text-shadow: 2px 2px #4d0000;
   color: #ffa3a3;
 }
-@media (max-width: 1023px) {
- }
 
 @media (max-width: 640px) {}
 
-@media (max-width: 767px) { 
+@media (max-width: 1024px) { 
   .container {
     overflow-y: auto;
 
@@ -101,3 +99,26 @@
 @media (min-width: 1280px) { }
 
 @media (min-width: 1536px) { }
+
+@media (min-width: 1280px) { 
+  .container {
+    width: 90vw;
+    height: auto;
+  }
+  .content {
+    display: flex;
+    flex-direction: row;
+    width: 90vw;
+    height: auto;
+  }
+  .headline {
+    width: 30%;
+    height: auto;
+    text-align: right;
+    padding: 0 25px 0 25px;
+  }
+  .thumbnail {
+    width: 70%;
+    height: auto;
+  }
+}

--- a/css/layout.css
+++ b/css/layout.css
@@ -65,3 +65,41 @@
   text-shadow: 2px 2px #4d0000;
   color: #ffa3a3;
 }
+@media (max-width: 1023px) {
+  body {
+    overflow: auto;
+  }
+  .container {
+    height: 100vh;
+    overflow: auto;
+    margin: 30px 0;
+  }
+  .content {
+    flex-direction: column;
+    height: auto;
+  }
+  .headline {
+    width: 100%;
+    text-align: center;
+    padding: 20px;
+  }
+  .thumbnail {
+    width: 100%;
+  }
+  .headline__heading {
+    line-height: 3rem;
+  }
+  .headline__text {
+    margin-top: 10px;
+  }
+ }
+
+@media (max-width: 640px) {}
+
+@media (min-width: 768px) and (max-width: 1023px) { }
+
+@media (min-width: 1024px) { }
+
+@media (min-width: 1280px) { }
+
+@media (min-width: 1536px) { }

--- a/css/layout.css
+++ b/css/layout.css
@@ -17,25 +17,25 @@
   width: 100%;
   height: 100vh;
 }
-.wrapper {
-  
-}
 .container {
   box-shadow: rgba(99, 0, 0, 0.3) 1px 3px 20px 3px;  
-  width: 80%;
+  width: auto;
+  height: 90vh;
   position: fixed;
   z-index: 10;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  overflow: auto;
 }
 .content {
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
+  height: 90vh;
 }
 .thumbnail {
-  width: 60%;
+  height: 60%;
+  padding: 20px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -45,61 +45,56 @@
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
 }
 .headline {
-  width: 40%;
+  height: 40%;
   background: rgba(0, 0, 0, 0.2);
   display: flex;
   align-items: center;
-  padding: 40px;
+  padding: 20px;
   color: #fff;
-  text-align: right;
   border-top: 1px solid rgba(255, 255, 255, 0.2);
   border-left: 1px solid rgba(0, 0, 0, 0.1);
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 
 }
 .headline__heading {
-  line-height: 3.5rem;
+  line-height: 1.5em;
   font-weight: 300;
-  font-size: 2.2rem;
+  font-size: 3vw;
   text-shadow: 2px 2px #660000;
 }
 .headline__text {
-  margin-top: 30px;
   text-shadow: 2px 2px #4d0000;
   color: #ffa3a3;
 }
 @media (max-width: 1023px) {
-  body {
-    /* overflow: auto; */
-  }
-  .container {
-    /* height: 100vh;
-    overflow: auto;
-    margin: 30px 0; */
-  }
-  .content {
-    flex-direction: column;
-    height: auto;
-  }
-  .headline {
-    width: 100%;
-    text-align: center;
-    padding: 20px;
-  }
-  .thumbnail {
-    width: 100%;
-  }
-  .headline__heading {
-    line-height: 3rem;
-  }
-  .headline__text {
-    margin-top: 10px;
-  }
  }
 
 @media (max-width: 640px) {}
 
-@media (min-width: 768px) and (max-width: 1023px) { }
+@media (max-width: 767px) { 
+  .container {
+    overflow-y: auto;
+
+  }
+  .content {
+    width: 90vmin;
+  }
+  .headline {
+    width: auto;
+    height: 30%;
+  }
+  .thumbnail {
+    height: 70%;
+    width: auto;
+  }
+  .headline__heading {
+    font-size: 6vw;
+  }
+  .headline__text {
+    font-size: 3vw;
+    margin-bottom: 10px;
+  }
+}
 
 @media (min-width: 1024px) { }
 

--- a/css/layout.css
+++ b/css/layout.css
@@ -1,31 +1,34 @@
-.video {
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  min-width: 100%;
-  min-height: 100%;
-  z-index: -1;
-}
-.container {
-  position: fixed;
-  height: 80vh;
-  width: 80%;
-  z-index: 10;
-  display: flex;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  box-shadow: rgba(99, 0, 0, 0.3) 1px 3px 20px 3px;  
+.video-wrapper {
+  position: relative;
 }
 .video-wrapper:before {
   content: '';
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   width: 100%;
   height: 100%;
   background: linear-gradient(180deg, rgba(184,4,4,0.72) 0%, rgba(161,3,3,0.83) 50%);
   z-index: 1;
+}
+.video {
+  object-fit: cover;
+  width: 100%;
+  height: 100vh;
+}
+.wrapper {
+  
+}
+.container {
+  box-shadow: rgba(99, 0, 0, 0.3) 1px 3px 20px 3px;  
+  width: 80%;
+  position: fixed;
+  z-index: 10;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  overflow: auto;
 }
 .content {
   display: flex;
@@ -67,12 +70,12 @@
 }
 @media (max-width: 1023px) {
   body {
-    overflow: auto;
+    /* overflow: auto; */
   }
   .container {
-    height: 100vh;
+    /* height: 100vh;
     overflow: auto;
-    margin: 30px 0;
+    margin: 30px 0; */
   }
   .content {
     flex-direction: column;

--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -1,16 +1,17 @@
 .thumbnail__list {
-  width: 85%;
+  /* width: 85%; */
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  padding-top: 1rem;
+  /* padding-top: 1rem; */
 }
 [class^="thumbnail__item-"] {
-  width: 47%;
+  width: calc((100% - 20px) / 2);
   display: flex;
   flex-direction: column;
   align-items: center;
   cursor: pointer;
+  position: relative;
 }
 .thumbnail-zoom {  
   transition: all .3s ease-in-out;
@@ -18,16 +19,16 @@
 .thumbnail-zoom:hover {
   transform: scale(1.05);
 }
-.thumbnail-bigger {
+/* .thumbnail-bigger {
   transform: scale(1.05);
-}
+} */
 [class^="thumbnail__item-"]:nth-child(1),
 [class^="thumbnail__item-"]:nth-child(2) {
   margin-bottom: 20px;
 }
 .thumbnail__item__img {
   box-shadow: rgba(139, 0, 0, 0.6) 2px 2px 4px 2px;
-  border-radius: 7px;
+  /* border-radius: 7px; */
   overflow: hidden;
   width: 100%;
   margin-bottom: 5px;
@@ -37,7 +38,7 @@
 }
 [class^="thumbnail__item"] img {
   width: 100%;
-  height: 100%;
+  height: auto;
   vertical-align: bottom;
 }
 .thumbnail-no-pointer:hover {
@@ -53,15 +54,67 @@
   font-size: 0.8rem;
   height: 1rem;
   color: #fff;
-}
-.text-lower-opacity {
-  opacity: 0.5;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 @media (max-width: 1023px) {
+  
+}
+@media (max-width: 767px) {
+  .container, .content {
+    height: 96vh;
+  }
+  .thumbnail {
+    padding: 10px;
+  }
   .thumbnail__list {
-    width: 95%;
+    flex-direction: row;
+    height: 100%;
   }
   [class^="thumbnail__item-"] {
-    width: 48.5%;
+    width: 100%;
+    height: calc((100% - 40px) / 4);
+  }
+  [class^="thumbnail__item-"]:nth-child(1),
+  [class^="thumbnail__item-"]:nth-child(2) {
+    margin-bottom: 0;
+  }
+  /* hover overlay effect */
+  .thumbnail__item__img {
+    /* max-height: 200px; */
+    /* overflow: hidden; */
+    margin-bottom: 0;
+    /* box-shadow: none; */
+  }
+  .thumbnail__item__img {
+    position: relative;
+    display: inline-block;
+  }
+  .thumbnail__item__img:after {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    content: "";
+    width: 100%;
+    height: 0;
+    background: #000;
+    opacity: .5;
+    transition: all .5s ease;
+  }
+  .thumbnail__item__img:hover:after {
+    height: 100%;
+    top: 0;
+  }
+  .wrong-answer .thumbnail__item__img:after {
+    height: 100%;
+    top: 0;
+  }
+  .thumbnail-zoom:hover,
+  .thumbnail-no-pointer {
+    transform: none;
+  
+      
   }
 }

--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -59,34 +59,9 @@
   left: 50%;
   transform: translate(-50%, -50%);
 }
-@media (max-width: 1023px) {
-  
-}
-@media (max-width: 767px) {
-  .container, .content {
-    height: 96vh;
-  }
-  .thumbnail {
-    padding: 10px;
-  }
-  .thumbnail__list {
-    flex-direction: row;
-    height: 100%;
-  }
-  [class^="thumbnail__item-"] {
-    width: 100%;
-    height: calc((100% - 40px) / 4);
-  }
-  [class^="thumbnail__item-"]:nth-child(1),
-  [class^="thumbnail__item-"]:nth-child(2) {
-    margin-bottom: 0;
-  }
   /* hover overlay effect */
   .thumbnail__item__img {
-    /* max-height: 200px; */
-    /* overflow: hidden; */
     margin-bottom: 0;
-    /* box-shadow: none; */
   }
   .thumbnail__item__img {
     position: relative;
@@ -113,8 +88,25 @@
   }
   .thumbnail-zoom:hover,
   .thumbnail-no-pointer {
-    transform: none;
-  
-      
+    transform: none;     
+  }
+@media (max-width: 767px) {
+  .container, .content {
+    height: 96vh;
+  }
+  .thumbnail {
+    padding: 10px;
+  }
+  .thumbnail__list {
+    flex-direction: row;
+    height: 100%;
+  }
+  [class^="thumbnail__item-"] {
+    width: 100%;
+    height: calc((100% - 40px) / 4);
+  }
+  [class^="thumbnail__item-"]:nth-child(1),
+  [class^="thumbnail__item-"]:nth-child(2) {
+    margin-bottom: 0;
   }
 }

--- a/css/thumbnail.css
+++ b/css/thumbnail.css
@@ -57,3 +57,11 @@
 .text-lower-opacity {
   opacity: 0.5;
 }
+@media (max-width: 1023px) {
+  .thumbnail__list {
+    width: 95%;
+  }
+  [class^="thumbnail__item-"] {
+    width: 48.5%;
+  }
+}

--- a/css/utility.css
+++ b/css/utility.css
@@ -4,3 +4,6 @@
 .visible {
   display: block;
 }
+.text-lower-opacity {
+  opacity: 0.5;
+}

--- a/index.html
+++ b/index.html
@@ -11,14 +11,14 @@
 		<title>Match Thumbnail and Headline</title>
 	</head>
 	<body>
+    
+    <div class="video-wrapper">
+      <video autoplay muted loop class="video">
+        <source src="images/background.mp4" type="video/mp4">
+      </video>
+    </div>
+    
     <div class="wrapper">
-
-      <div class="video-wrapper">
-        <video autoplay muted loop class="video">
-          <source src="images/background.mp4" type="video/mp4">
-        </video>
-      </div>
-
       <div class="container">
         <div class="content">
           <div class="headline">
@@ -33,10 +33,10 @@
           </div>
         </div>
       </div>
+    </div>
       
       <div class="detail"></div>
       <div class="overlay"></div>
-    </div>
 
 		<script src="js/app.js"></script>
 	</body>

--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@
         <div class="content">
           <div class="headline">
             <div class="headline__content">
-              <h2 class="headline__heading"></h2>
               <p class="headline__text text-lower-opacity">[ Choose thumbnail best matches the headline ]</p>
+              <h2 class="headline__heading"></h2>
             </div>
           </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -79,25 +79,28 @@ async function renderThumbnails() {
 thumbnailsContainer.addEventListener('click', function(e) {
 
   let thumbnailItem = e.target.parentNode.parentNode;
+  console.log("thumbnailItem", thumbnailItem)
 
   if(isPlaying) {
     
     // TODO: add condition when fire thumbnail click event
     if(thumbnailItem.className.includes(indexOfAnswer)) {
-    
         // TODO: change text in <span>
         e.target.parentNode.classList.add('thumbnail-glow')
         
         thumbnailItem.children[1].textContent += 'Correct! Click for Detail';   
 
         thumbnailItem.classList.remove('thumbnail-zoom');
-        thumbnailItem.classList.add('thumbnail-bigger');
+        // thumbnailItem.classList.add('thumbnail-bigger');
         
         Array.from(thumbnailItem.parentNode.children).forEach(el => {
 
           if(!el.className.includes(indexOfAnswer)) {
-            el.classList.remove('thumbnail-zoom')
-            el.classList.add('thumbnail-no-pointer')
+
+            console.log("el", el)
+
+            el.parentNode.classList.remove('thumbnail-zoom');
+            el.parentNode.classList.add('thumbnail-no-pointer');
           }
         })
         thumbnailItem.classList.remove('thumbnail-pointer');
@@ -109,8 +112,7 @@ thumbnailsContainer.addEventListener('click', function(e) {
         })    
       } else {
         thumbnailItem.classList.remove('thumbnail-zoom');
-        thumbnailItem.classList.add('thumbnail-no-pointer');
-        thumbnailItem.children[1].classList.add('text-lower-opacity');
+        thumbnailItem.classList.add('thumbnail-no-pointer', 'wrong-answer');
         thumbnailItem.children[1].textContent = 'Incorrect';
     }
   }


### PR DESCRIPTION
## Setting breakpoints
I'm going to use the same width as Tailwind CSS breakpoints.
```
@media (min-width: 640px) { ... }

@media (min-width: 768px) { ... }

@media (min-width: 1024px) { ... }

@media (min-width: 1280px) { ... }

@media (min-width: 1536px) { ... }
```

## Headline top, thumbnails bottom on smaller screen sizes
For smaller screen size or portrait screen, I set layout to place headline on top and thumbnails on bottom.

## Changing hovering effect for thumbnails
Initially, when thumbnail is clicked either a message 'Correct' or 'Incorrect' was shown under it. I changed to show message on thumbnail so that each thumbnails can get closer to each other.